### PR TITLE
refactor : 아이템 등록할 때 이미지 저장시 이미지 원본 압축코드 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'net.coobird:thumbnailator:0.4.14'
 	testImplementation 'org.springframework.security:spring-security-test'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/net/supercoding/backend/domain/item/service/ItemService.java
+++ b/src/main/java/net/supercoding/backend/domain/item/service/ItemService.java
@@ -20,6 +20,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.server.ResponseStatusException;
+import net.coobird.thumbnailator.Thumbnails;
 
 @Service
 @RequiredArgsConstructor
@@ -42,18 +43,22 @@ public class ItemService {
         if (image != null && !image.isEmpty()) {
             String today = LocalDate.now().toString();
 
-            // src/main/resources/static 경로를 절대 경로로 지정
-            String projectRoot = System.getProperty("user.dir"); // 현재 프로젝트 루트
+            String projectRoot = System.getProperty("user.dir");
             String staticPath = projectRoot + "/src/main/resources/static/" + today;
 
             File uploadDir = new File(staticPath);
             if (!uploadDir.exists()) uploadDir.mkdirs();
 
-            String savedFileName = UUID.randomUUID() + "_" + image.getOriginalFilename();
+            String savedFileName = UUID.randomUUID() + ".jpg";
             File saveFile = new File(uploadDir, savedFileName);
-            image.transferTo(saveFile);
 
-            // 프론트에서 접근 가능한 URL 경로
+            // Thumbnailator 이미지 처리용 자바 라이브러리 사용
+            Thumbnails.of(image.getInputStream())
+                    .size(450, 450)         // 비율 유지하면서 둘 중 큰 쪽을 450px로 맞춤
+                    .outputFormat("jpg")    // JPEG 형식 저장
+                    .outputQuality(0.85)    // 85% 품질 압축
+                    .toFile(saveFile);
+
             String imageUrl = "/" + today + "/" + savedFileName;
             newItemEntity.setItemImageUrl(imageUrl);
         }


### PR DESCRIPTION
refactor : 아이템 등록할 때 이미지 저장시 이미지 원본 압축코드 추가

이미지 화질 85% 압축

사이즈 비율 그대로, 가로 세로 긴쪽 기준 450으로 맞춰서 저장

이미지 처리용 자바 라이브러리 Thumbnailator 사용